### PR TITLE
Update ie8.js

### DIFF
--- a/comparisons/elements/remove_class/ie8.js
+++ b/comparisons/elements/remove_class/ie8.js
@@ -1,4 +1,16 @@
 if (el.classList)
   el.classList.remove(className);
 else
-  el.className = el.className.replace(new RegExp('(^|\\b)(\\s*)' + className.split(' ').join('(\\s*)|(\\s*)') + '(\\s*)(\\b|$)', 'g'), ' ');
+  el.className = el.className.replace(
+      new RegExp( '(^|\\s)('
+        + className.split( \s ).filter(
+          function ( e ) { return e; }
+        ).join( '|' )
+        + ')(\\s|$)' , 'gm'
+      )
+      , ' '
+  ).split( ' ' ).filter(
+    function ( e ) { return e; }
+  ).join( ' ' );
+// dependent on filter, see polyFill for instance @ MDN :
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter#Polyfill .


### PR DESCRIPTION
With this update className = 'no-js' no longer removes the 'no-js' part from an element.className that contains 'hey-no-js' .
This update removes exuberant whitespace-characters, works over multiple lines (in case someone did that) both from el.className & from give className-param.
